### PR TITLE
Changed return of custom types to pointers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
         "vscode": {
             "extensions": [
                 "streetsidesoftware.code-spell-checker",
-                "golang.go"
+                "golang.go",
+                "dnut.rewrap-revived"
             ]
         }
     }

--- a/InfoDbFunctions_test.go
+++ b/InfoDbFunctions_test.go
@@ -156,26 +156,26 @@ func Test_hanaUtilClient_GetBackupSummary(t *testing.T) {
 	tests := []struct {
 		name    string
 		fields  fields
-		want    BackupSummary
+		want    *BackupSummary
 		wantErr bool
 	}{
-		{"Good01", fields{db1, ""}, BackupSummary{
+		{"Good01", fields{db1, ""}, &BackupSummary{
 			100, 10, 90, 30, 0, 0, 0, 1024000, 512000, 0, 0, 0, 0, 10240, genTime, genTime, genTime}, false},
-		{"Good02", fields{db1, ""}, BackupSummary{
+		{"Good02", fields{db1, ""}, &BackupSummary{
 			60, 10, 10, 10, 10, 10, 10, 1024, 1024, 1024, 1024, 1024, 1024, 10240, genTime, genTime, genTime}, false},
-		{"BackupCatalogSizeDbError", fields{db1, ""}, BackupSummary{}, true},
-		{"OldestBackupUnexpectedResult", fields{db1, ""}, BackupSummary{}, true},
-		{"OldestBackupScanError", fields{db1, ""}, BackupSummary{}, true},
-		{"OldestBackupDbError", fields{db1, ""}, BackupSummary{}, true},
-		{"BackupSizeUnexpectedResult", fields{db1, ""}, BackupSummary{}, true},
-		{"BackupSizeDbError", fields{db1, ""}, BackupSummary{}, true},
-		{"BackupSizeScanError", fields{db1, ""}, BackupSummary{}, true},
-		{"GetBackupCountUnexpectedResult", fields{db1, ""}, BackupSummary{}, true},
-		{"BackupCountScanError", fields{db1, ""}, BackupSummary{}, true},
-		{"BackupCountDbError", fields{db1, ""}, BackupSummary{}, true},
-		{"BackupCatalogEntryCountScanError", fields{db1, ""}, BackupSummary{}, true},
-		{"BackupCatalogEntryCountDbError", fields{db1, ""}, BackupSummary{}, true},
-		{"CurrentTimeError", fields{db1, ""}, BackupSummary{}, true},
+		{"BackupCatalogSizeDbError", fields{db1, ""}, nil, true},
+		{"OldestBackupUnexpectedResult", fields{db1, ""}, nil, true},
+		{"OldestBackupScanError", fields{db1, ""}, nil, true},
+		{"OldestBackupDbError", fields{db1, ""}, nil, true},
+		{"BackupSizeUnexpectedResult", fields{db1, ""}, nil, true},
+		{"BackupSizeDbError", fields{db1, ""}, nil, true},
+		{"BackupSizeScanError", fields{db1, ""}, nil, true},
+		{"GetBackupCountUnexpectedResult", fields{db1, ""}, nil, true},
+		{"BackupCountScanError", fields{db1, ""}, nil, true},
+		{"BackupCountDbError", fields{db1, ""}, nil, true},
+		{"BackupCatalogEntryCountScanError", fields{db1, ""}, nil, true},
+		{"BackupCatalogEntryCountDbError", fields{db1, ""}, nil, true},
+		{"CurrentTimeError", fields{db1, ""}, nil, true},
 	}
 	for _, tt := range tests {
 		/*Set up per case mocking*/
@@ -458,14 +458,14 @@ func Test_hanaUtilClient_GetLogSegmentStats(t *testing.T) {
 	tests := []struct {
 		name    string
 		fields  fields
-		want    LogSegmentsStats
+		want    *LogSegmentsStats
 		wantErr bool
 	}{
-		{"Good", fields{db1, ""}, LogSegmentsStats{10, 10240, 50, 51200}, false},
-		{"NoRows", fields{db1, ""}, LogSegmentsStats{}, false},
-		{"DbError", fields{db1, ""}, LogSegmentsStats{}, true},
-		{"ScanError", fields{db1, ""}, LogSegmentsStats{}, true},
-		{"UnexpectedReturn", fields{db1, ""}, LogSegmentsStats{}, true},
+		{"Good", fields{db1, ""}, &LogSegmentsStats{10, 10240, 50, 51200}, false},
+		{"NoRows", fields{db1, ""}, &LogSegmentsStats{}, false},
+		{"DbError", fields{db1, ""}, nil, true},
+		{"ScanError", fields{db1, ""}, nil, true},
+		{"UnexpectedReturn", fields{db1, ""}, nil, true},
 	}
 	for _, tt := range tests {
 		/*Set up per case mocking*/
@@ -530,12 +530,12 @@ func TestHanaUtilClient_GetBackupSummaryBeforeBackupID(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		want    BackupSummary
+		want    *BackupSummary
 		wantErr bool
 	}{
-		{"Good01", fields{db1, ""}, args{"123"}, BackupSummary{
+		{"Good01", fields{db1, ""}, args{"123"}, &BackupSummary{
 			100, 10, 90, 0, 0, 0, 0, 1024000, 512000, 0, 0, 0, 0, 10240, genTime, genTime, genTime}, false},
-		{"Bad", fields{db1, ""}, args{"123"}, BackupSummary{}, true},
+		{"Bad", fields{db1, ""}, args{"123"}, nil, true},
 	}
 	for _, tt := range tests {
 		/*per case mocking*/

--- a/modifyDbFunctions_test.go
+++ b/modifyDbFunctions_test.go
@@ -29,23 +29,23 @@ func Test_hanaUtilClient_TruncateBackupCatalog(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		want    TruncateStats
+		want    *TruncateStats
 		wantErr bool
 	}{
-		{"Good", fields{db1, ""}, args{28, false}, TruncateStats{100, 0}, false},
-		{"GoodPartialDelete", fields{db1, ""}, args{28, false}, TruncateStats{99, 0}, false},
-		{"GoodNoDelete", fields{db1, ""}, args{31, false}, TruncateStats{100, 0}, false},
-		{"GoodComplete", fields{db1, ""}, args{31, true}, TruncateStats{99, 99999}, false},
-		{"GoodCompleteNoDelete", fields{db1, ""}, args{31, true}, TruncateStats{75, 555444}, false},
-		{"GoodCompletePartialDelete", fields{db1, ""}, args{28, true}, TruncateStats{1000, 1000000}, false},
-		{"2ndGetTruncateDbError", fields{db1, ""}, args{28, false}, TruncateStats{}, true},
-		{"2ndGetTruncateScanError", fields{db1, ""}, args{28, false}, TruncateStats{}, true},
-		{"TruncateDbError", fields{db1, ""}, args{90, false}, TruncateStats{}, true},
-		{"TruncateCompleteDbError", fields{db1, ""}, args{90, true}, TruncateStats{}, true},
-		{"1stGetTruncateDbError", fields{db1, ""}, args{60, false}, TruncateStats{}, true},
-		{"1stGetTruncateScanError", fields{db1, ""}, args{60, false}, TruncateStats{}, true},
-		{"GetBackupIdScanError", fields{db1, ""}, args{14, false}, TruncateStats{}, true},
-		{"GetBackupIdDbError", fields{db1, ""}, args{14, false}, TruncateStats{}, true},
+		{"Good", fields{db1, ""}, args{28, false}, &TruncateStats{100, 0}, false},
+		{"GoodPartialDelete", fields{db1, ""}, args{28, false}, &TruncateStats{99, 0}, false},
+		{"GoodNoDelete", fields{db1, ""}, args{31, false}, &TruncateStats{100, 0}, false},
+		{"GoodComplete", fields{db1, ""}, args{31, true}, &TruncateStats{99, 99999}, false},
+		{"GoodCompleteNoDelete", fields{db1, ""}, args{31, true}, &TruncateStats{75, 555444}, false},
+		{"GoodCompletePartialDelete", fields{db1, ""}, args{28, true}, &TruncateStats{1000, 1000000}, false},
+		{"2ndGetTruncateDbError", fields{db1, ""}, args{28, false}, nil, true},
+		{"2ndGetTruncateScanError", fields{db1, ""}, args{28, false}, nil, true},
+		{"TruncateDbError", fields{db1, ""}, args{90, false}, nil, true},
+		{"TruncateCompleteDbError", fields{db1, ""}, args{90, true}, nil, true},
+		{"1stGetTruncateDbError", fields{db1, ""}, args{60, false}, nil, true},
+		{"1stGetTruncateScanError", fields{db1, ""}, args{60, false}, nil, true},
+		{"GetBackupIdScanError", fields{db1, ""}, args{14, false}, nil, true},
+		{"GetBackupIdDbError", fields{db1, ""}, args{14, false}, nil, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This breaking change makes it so when hanautil returns pointers custom types rather than the values of custom types.

Returning pointers to custom types is idiomatic in golang, it also avoids copying data to a returned types and is therefore more efficient.